### PR TITLE
Bug in line submerged weight in moorpy.system.parseYAML

### DIFF
--- a/moorpy/system.py
+++ b/moorpy/system.py
@@ -826,13 +826,14 @@ class System():
         # line types
         for d in data['line_types']:
             dia = float(d['diameter']    )
-            w   = float(d['mass_density'])*self.g
+            m   =  float(d['mass_density'])
+            w   = (m - np.pi/4*dia**2 *self.rho)*self.g #submerged weight
             EA  = float(d['stiffness']   )
             if d['breaking_load']:
                 MBL = float(d['breaking_load'])
             else:
                 MBL = 0
-            self.lineTypes[d['name']] = dict(name=d['name'], d_vol=dia, w=w, EA=EA, MBL=MBL)
+            self.lineTypes[d['name']] = dict(name=d['name'], d_vol=dia, w=w, m=m, EA=EA, MBL=MBL)
             
         # rod types TBD
         


### PR DESCRIPTION
In moorpy.system.parseYAML function, corrected the definition of submerged weight. This is affecting the mooring system set up in [RAFT model](https://github.com/WISDEM/RAFT/blob/c7499ca28bab09c78e1873674930126268b5d95f/raft/raft_fowt.py#L176).