### PR TITLE
Adding features to MD unload function to support FFarm integration:

### DIFF
--- a/moorpy/system.py
+++ b/moorpy/system.py
@@ -1222,8 +1222,7 @@ class System():
             # Check length of phi if given
             if phi:
                 if len(phi) != len(self.bodyList):
-                    raise ValueError(f"Inconsistency in the size of the given platform rotation angle phi. 
-                                     There are {len(self.bodyList)} bodies in MS but only {len(phi)} angles are given.")
+                    raise ValueError(f"Inconsistency in the size of the given platform rotation angle phi. There are {len(self.bodyList)} bodies in MS but only {len(phi)} angles are given.")
                 
             # Set up the dictionary that will be used to write the OPTIONS section
             if not MDoptionsDict:

--- a/moorpy/system.py
+++ b/moorpy/system.py
@@ -1020,7 +1020,7 @@ class System():
 
 
     def unload(self, fileName, MDversion=2, line_dL=0, rod_dL=0, flag='p', 
-               outputList=[], Lm=[0], T_half=42, phiV=None, MDoptionsDict={}):
+               outputList=[], Lm=[0], T_half=42, phi=None, MDoptionsDict={}):
         '''Unloads a MoorPy system into a MoorDyn-style input file
 
         Parameters
@@ -1040,7 +1040,7 @@ class System():
         T_half : float, optional
             For tuning response of viscoelastic model, the period when EA is
             half way between the static and dynamic values [s]. Default is 42.
-        phiV : list of floats, optional 
+        phi : list of floats, optional 
             platform's rotations variables [deg]. Defaults to None and platforms are not unrotated.
         MDoptionsDict: dictionary, optional
             MoorDyn Options. If not given, default options are considered.
@@ -1135,8 +1135,8 @@ class System():
                             if attached_Point == point.number:
                                 #point_type = "Body" + str(body.number)
                                 point_type = "Vessel"                                
-                                if phiV:
-                                    c, s = np.cos(np.radians(-phiV[i])), np.sin(np.radians(-phiV[i]))
+                                if phi:
+                                    c, s = np.cos(np.radians(-phi[i])), np.sin(np.radians(-phi[i]))
                                     R = np.array([[c, -s, 0],
                                                   [s,  c, 0],
                                                   [0,  0, 1]])
@@ -1219,6 +1219,12 @@ class System():
             #version = 
             #description = 
             
+            # Check length of phi if given
+            if phi:
+                if len(phi) != len(self.bodyList):
+                    raise ValueError(f"Inconsistency in the size of the given platform rotation angle phi. 
+                                     There are {len(self.bodyList)} bodies in MS but only {len(phi)} angles are given.")
+                
             # Set up the dictionary that will be used to write the OPTIONS section
             if not MDoptionsDict:
                 MDoptionsDict = dict(dtM=0.001, kb=3.0e6, cb=3.0e5, TmaxIC=60)        # start by setting some key default values
@@ -1424,8 +1430,8 @@ class System():
 
                                 if attached_Point == point.number:
                                     point_type = "Body" + str(body.number)
-                                    if phiV:
-                                        c, s = np.cos(np.radians(-phiV[i])), np.sin(np.radians(-phiV[i]))
+                                    if phi:
+                                        c, s = np.cos(np.radians(-phi[i])), np.sin(np.radians(-phi[i]))
                                         R = np.array([[c, -s, 0],
                                                     [s,  c, 0],
                                                     [0,  0, 1]])


### PR DESCRIPTION
This PR along helps the user to unload MoorDyn input files for FAST.Farm using PR [#40](https://github.com/OpenFAST/openfast_toolbox/pull/40) in openfast toolbox from MoorPy object to allow FAModel to generate FFarm input files.  

## Purpose
It addresses the need to have fairlead positions defined in the 'unrotated' local reference frame of the platforms. FFarm, then rotates the fairlead based on the ElastoDyn inputs. These examples show two cases with two turbines having different headings. The red lines are the MD input information (before rotation) and the white lines are after applying ED rotations to the farilead connections.
<img width="1080" alt="Screenshot 2025-02-28 at 12 53 56 PM" src="https://github.com/user-attachments/assets/6cde03ec-4c31-401e-a3c3-a05ae0db3c0b" />

<img width="885" alt="Screenshot 2025-02-28 at 12 54 25 PM" src="https://github.com/user-attachments/assets/82068a3a-da59-4fe2-9144-ba786fee914b" />

**Main changes:** 
1) Allowing unload to have platform headings to unrotate turbines such that MD output file has fairlead points in the local unrotated reference frame. 

2) Allowing optional MD dictionary to be an input by the user (if not given, default values will be used) [to facilitate dynamic relaxation anlaysis].

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)
