### PR TITLE
Bugfixes for MoorDyn post processing 

### DIFF
--- a/moorpy/helpers.py
+++ b/moorpy/helpers.py
@@ -1868,6 +1868,12 @@ def read_mooring_file(dirName,fileName):
     
     data2 = np.array(data)
     
+    # Check if *** characters in data2 and if so replace with 0
+    for i in range(len(data2)):
+        for j in range(len(data2[i])):
+            if data2[i][j].count('***') > 0:
+                data2[i][j] = '0.0'
+
     data3 = data2.astype(float)
     
     return data3, ch, channels, units    

--- a/moorpy/line.py
+++ b/moorpy/line.py
@@ -53,7 +53,8 @@ class Line():
         self.type = lineType    # dictionary of a System.lineTypes entry
         self.cost = {}          # empty dictionary to contain cost information
         
-        self.EA = self.type['EA']  # use the default stiffness value for now (may be modified if using nonlinear elasticity) [N]
+        if not self.isRod:
+            self.EA = self.type['EA']  # use the default stiffness value for now (may be modified if using nonlinear elasticity) [N]
         
         self.nNodes = int(nSegs) + 1
         self.cb = float(cb)    # friction coefficient (will automatically be set negative if line is fully suspended)

--- a/moorpy/system.py
+++ b/moorpy/system.py
@@ -4148,7 +4148,7 @@ class System():
         # Animation: update the figure with the updated coordinates from update_Coords function
         # NOTE: the animation needs to be stored in a variable, return out of the method, and referenced when calling self.animatelines()
         line_ani = animation.FuncAnimation(fig, self.updateCoords, np.arange(1, nFrames-1, speed), fargs=(colortension, cmap_tension, label, dt),
-                                           interval=1, repeat=repeat, repeat_delay=delay, blit=False)
+                                           interval=interval, repeat=repeat, repeat_delay=delay, blit=False)
                                             # works well when np.arange(...nFrames...) is used. Others iterable ways to do this
         
         return line_ani


### PR DESCRIPTION
## Purpose
Minor bug fixes to improve MoorDyn output plotting:

- Bugfix to allow for plotting MoorDyn outputs that include rods using MoorPy. 
- Code to check for `***` in MoorDyn outputs. This was an old issue with MoorDyn-F that was fixed in https://github.com/OpenFAST/openfast/pull/2658, but may still be happening for people using older OpenFAST versions.
- Enables the interval input for animateLines, allowing the animation speed to be controlled. 

## Type of change
What types of change is it?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Animate MoorDyn-F outputs with rods

## Checklist

- [X] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation