### PR TITLE
Add cost paper to docs and yamls, revert default cost change

### DIFF
--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -21,3 +21,22 @@ zSpan parameter defines the lower and upper extents of the point's
 height, relative to the point coordinate, r. This provides a constant 
 hydrostatic stiffness when the Point crosses the free surface, but has no
 effect the rest of the time.
+    
+Cost Coefficients
+^^^^^^^^^^^^^^^^^
+
+MoorPy contains material unit cost coefficients for mooring lines, connection hardware,
+and anchors. These represent the material cost per unit, i.e. the cost if you were to buy 
+the product directly at the factory door. Thus they include the manufacturing costs, but
+not the transport costs from factory to installation site. These coefficients were derived
+from conversations with suppliers and developers of mooring systems for offshore energy 
+systems. These cost coefficients are located in the MoorProps_newCosts.yaml and 
+PointProps_default.yaml files. They are presented in:
+
+  `Davies, R, Baca, E, & Hall, M. "An Updated Mooring Cost Modeling Tool Set With Application to a Reference Model
+  Wave Energy Converter." Proceedings of the ASME 2025 44th International Conference on Ocean, Offshore and Arctic 
+  Engineering. Volume 5: Ocean Renewable Energy. Vancouver, British Columbia, Canada. June 22–27, 2025. V005T09A066. 
+  ASME. <https://doi.org/10.1115/OMAE2025-156384>`_
+
+Additional cost coefficients beyond those presented in the above publication have been added to the 
+YAMLs based on data received from industry partners.

--- a/moorpy/MoorProps_default.yaml
+++ b/moorpy/MoorProps_default.yaml
@@ -1,4 +1,4 @@
-# Default mooring line property coefficients for MoorPy
+# Old default mooring line property coefficients for MoorPy
 # The following is YAML syntax and follows a heirarchy of
 # lineProps -> [line material name] -> [line material coefficients]
 
@@ -9,15 +9,15 @@
 #    MBL_d     :     # minimum breaking load per diameter [N/m]
 #    MBL_d2    :     # minimum breaking load per diameter^2 [N/m^2]
 #    MBL_d3    :     # minimum breaking load per diameter^3 [N/m^3]
-#    MBL_dmin  :     # minimum valid diameter for the MBL curve (values < 0 ignored) [m]
-#    MBL_dmax  :     # maximum valid diameter for the MBL curve (values < 0 ignored) [m]
+#    MBL_dmin  :     # minimum valid diameter for the MBL curve (values < 0 ignored)
+#    MBL_dmax  :     # maximum valid diameter for the MBL curve (values < 0 ignored)
 #    
 #    EA_0      :     # stiffness offset [N]
 #    EA_d      :     # stiffness per diameter [N/m]
 #    EA_d2     :     # stiffness per diameter^2 [N/m^2]
 #    EA_d3     :     # stiffness per diameter^3 [N/m^3]
-#    EA_dmin   :     # minimum valid diameter for the EA curve (values < 0 ignored) [m]
-#    EA_dmax   :     # maximum valid diameter for the EA curve (values < 0 ignored) [m]
+#    EA_dmin   :     # minimum valid diameter for the EA curve (values < 0 ignored)
+#    EA_dmax   :     # maximum valid diameter for the EA curve (values < 0 ignored)
 #    EA_MBL    :     # (quasi-static) stiffness per MBL [N/N] (aka Kr, Krs) 
 #    EAd_MBL   :     # dynamic stiffness per MBL [N/N] (aka Krd or Krd_alpha)
 #    EAd_MBL_Lm:     # dynamic stiffness per MBL per fraction of mean load (not %) [N/N] (aka or Krd_beta)
@@ -27,12 +27,12 @@
 #    NOTE: Only one of the above three variables can be used as input!
 #    
 #    cost_0    :     # cost offset [$/m]
-#    cost_d    :     # cost per diameter [$/m^2]
-#    cost_d2   :     # cost per diameter^2 [$/m^3]
-#    cost_d3   :     # cost per diameter^2 [$/m^4]
+#    cost_d    :     # cost per meter per diameter [$/m^2]
+#    cost_d2   :     # cost per meter per diameter^2 [$/m^3]
+#    cost_d3   :     # cost per meter per diameter^2 [$/m^4]
 #    cost_mass :     # cost per mass [$/kg]
-#    cost_EA   :     # cost per stiffness [$/m/N]
-#    cost_MBL  :     # cost per MBL [$/m/N]
+#    cost_EA   :     # cost per meter per stiffness [$/m/N] 
+#    cost_MBL  :     # cost per meter per MBL [$/m/N] 
 #
 #    Cd        :     # drag coefficient based on DNV-OS-E301 adjusted for use with volumetric diameter
 #    Cd_ax     :     # axial drag coefficient based on DNV-OS-E301 adjusted for use with volumetric diameter
@@ -47,7 +47,8 @@
 # - The chain MBL uses a cubic function, so be aware if you are researching theoretical chains with diameters greater than about 360mm, as the MBL will then decrease
 # - Chain EA values not provided in manufacturer catalogs, so the below coefficients are taken from DNV-OS-E301 2013
 
-
+# Note: costs combine all provided coefficients. If a coefficient is not provided it is assumed zero. All provided values will be used according to: 
+# cost per meter = 'cost_0' + 'cost_d' * d + 'cost_d2' * d**2 + 'cost_d3' * d**3 + 'cost_mass' * mass per meter + 'cost_EA' * EA + 'cost_MBL' * MBL
 
 lineProps: 
 

--- a/moorpy/MoorProps_newCosts.yaml
+++ b/moorpy/MoorProps_newCosts.yaml
@@ -1,4 +1,10 @@
-# Default mooring line property coefficients for MoorPy with updated cost curves based on work presented in OMAE2025-156384
+# Default line properties with cost curves based on work presented in:
+  # Davies, R, Baca, E, & Hall, M. "An Updated Mooring Cost Modeling Tool Set With Application to a Reference Model
+  # Wave Energy Converter." Proceedings of the ASME 2025 44th International Conference on Ocean, Offshore and Arctic 
+  # Engineering. Volume 5: Ocean Renewable Energy. Vancouver, British Columbia, Canada. June 22–27, 2025. V005T09A066. 
+  # ASME. https://doi.org/10.1115/OMAE2025-156384
+
+
 # The following is YAML syntax and follows a heirarchy of
 # lineProps -> [line material name] -> [line material coefficients]
 
@@ -26,13 +32,13 @@
 #    density   :     # density of the line material [kg/m^3] (e.g., chain density = 7850 kg/m^3)
 #    NOTE: Only one of the above three variables can be used as input!
 #    
-#    cost_0    :     # cost offset [2024$/m]
-#    cost_d    :     # cost per meter per diameter [2024$/m^2]
-#    cost_d2   :     # cost per meter per diameter^2 [2024$/m^3]
-#    cost_d3   :     # cost per meter per diameter^2 [2024$/m^4]
-#    cost_mass :     # cost per mass [2024$/kg]
-#    cost_EA   :     # cost per stiffness [2024$/m/N] 
-#    cost_MBL  :     # cost per MBL [2024$/m/N] 
+#    cost_0    :     # cost offset [$/m]
+#    cost_d    :     # cost per meter per diameter [$/m^2]
+#    cost_d2   :     # cost per meter per diameter^2 [$/m^3]
+#    cost_d3   :     # cost per meter per diameter^2 [$/m^4]
+#    cost_mass :     # cost per mass [$/kg]
+#    cost_EA   :     # cost per meter per stiffness [$/m/N] 
+#    cost_MBL  :     # cost per meter per MBL [$/m/N] 
 #
 #    Cd        :     # drag coefficient based on DNV-OS-E301 adjusted for use with volumetric diameter
 #    Cd_ax     :     # axial drag coefficient based on DNV-OS-E301 adjusted for use with volumetric diameter
@@ -47,8 +53,8 @@
 # - The chain MBL uses a cubic function, so be aware if you are researching theoretical chains with diameters greater than about 360mm, as the MBL will then decrease
 # - Chain EA values not provided in manufacturer catalogs, so the below coefficients are taken from DNV-OS-E301 2013
 
-# Note costs combine all provided coefficients. If a coefficient is not provided it is assumed zero. All provided values will be used according to: 
-# cost = 'cost_0' + 'cost_d'*d + 'cost_d2'*d**2 + 'cost_d3'*d**3 + 'cost_mass'*mass + 'cost_EA'*EA + 'cost_MBL'*MBL
+# Note: costs combine all provided coefficients. If a coefficient is not provided it is assumed zero. All provided values will be used according to: 
+# cost per meter = 'cost_0' + 'cost_d' * d + 'cost_d2' * d**2 + 'cost_d3' * d**3 + 'cost_mass' * mass per meter + 'cost_EA' * EA + 'cost_MBL' * MBL
 
 lineProps: 
 
@@ -135,8 +141,3 @@ lineProps:
     Ca_ax     :  0.15      # axial added mass coefficient based on Bureau Veritas 493-NR_2021-07
     cost_d    : -2.27e3    # cost per meter per diameter [2024$/m^2]
     cost_d2   :  1.10e5    # cost per meter per diameter^2 [2024$/m^3]
-
-
-
-
-

--- a/moorpy/PointProps_default.yaml
+++ b/moorpy/PointProps_default.yaml
@@ -1,8 +1,14 @@
 # The ABCD YAML
 
-# Default point properties with cost curves based on work presented in OMAE2025-156384
-# The following is YAML syntax and follows a heirarchy of
+# Default point properties with cost curves based on work presented in:
+  # Davies, R, Baca, E, & Hall, M. "An Updated Mooring Cost Modeling Tool Set With Application to a Reference Model
+  # Wave Energy Converter." Proceedings of the ASME 2025 44th International Conference on Ocean, Offshore and Arctic 
+  # Engineering. Volume 5: Ocean Renewable Energy. Vancouver, British Columbia, Canada. June 22–27, 2025. V005T09A066. 
+  # ASME. https://doi.org/10.1115/OMAE2025-156384
 
+
+
+# The following is YAML syntax and follows a heirarchy of
 # AnchorProps  -> [anchor type name]          -> [component coefficients] NOT SUPPORTED - potential approach
 # BuoyProps    -> [buoy type name]            -> [component coefficients]
 # ConnectProps -> [connection component name] -> [component coefficients]
@@ -55,7 +61,7 @@
     # frac_a_<anchor name>:   # fraction of total anchor size per anchor of this type. Default is 1/total number of anchors.
     # frac_b_<buoy name>  :   # fraction of total buoyancy per buoy of this type. Default is 1/total number of buoys.
 
-AnchorProps: # TODO: do we even want the old installation and decommissioning costs here?
+AnchorProps: 
 
   # example       :
     # matcost_m    :     # material cost per mass [$/kg]

--- a/moorpy/helpers.py
+++ b/moorpy/helpers.py
@@ -768,7 +768,7 @@ def loadLineProps(source):
     elif source is None or source=="default":
         import os
         mpdir = os.path.dirname(os.path.realpath(__file__))
-        with open(os.path.join(mpdir,"MoorProps_newCosts.yaml")) as file:
+        with open(os.path.join(mpdir,"MoorProps_default.yaml")) as file:
             source = yaml.load(file, Loader=yaml.FullLoader)
         
     elif type(source) is str:


### PR DESCRIPTION
## Purpose
This PR adds a reference to the cost data in the PointProps and MoorProps_newCost yamls. It also reverts the change to the yaml used for line cost calculation back to MoorProps_default. 

Additionally, comments in MoorProps_default and MoorProps_newCosts have been adjusted so the two yamls are identical except for the cost coefficients.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
n/a
## Checklist

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [X] I have added necessary documentation