### PR TITLE
A new feature to enable plot2d to show the line depth in 2D.

### DIFF
--- a/moorpy/subsystem.py
+++ b/moorpy/subsystem.py
@@ -467,7 +467,7 @@ class Subsystem(System, Line):
             plt.show()    
     
     
-    def drawLine2d(self, Time, ax, color="k", endpoints=False, Xuvec=[1,0,0], Yuvec=[0,0,1], Xoff=0, Yoff=0, colortension=False, plotnodes=[], plotnodesline=[],label="",cmap='rainbow', alpha=1.0, linewidth = 1):
+    def drawLine2d(self, Time, ax, color="k", endpoints=False, Xuvec=[1,0,0], Yuvec=[0,0,1], Xoff=0, Yoff=0, colortension=False, depth_cmap_settings=None, plotnodes=[], plotnodesline=[],label="",cmap='rainbow', alpha=1.0, linewidth = 1):
         '''wrapper to System.plot2d with some transformation applied'''
         
         for i, line in enumerate(self.lineList):
@@ -497,8 +497,21 @@ class Subsystem(System, Line):
             Xs2d = Xs*Xuvec[0] + Ys*Xuvec[1] + Zs*Xuvec[2] + Xoff
             Ys2d = Xs*Yuvec[0] + Ys*Yuvec[1] + Zs*Yuvec[2] + Yoff
             
-            
-            if colortension:    # if the mooring lines want to be plotted with colors based on node tensions
+            if depth_cmap_settings is not None: 
+                import matplotlib.cm as cm
+                import matplotlib.colors as mcolors
+                cmap_obj = cm.get_cmap(depth_cmap_settings.get("cmap", "Blues"))
+                norm = mcolors.Normalize(
+                    vmin=depth_cmap_settings.get("vmin", 0),
+                    vmax=depth_cmap_settings.get("vmax", 1)
+                )                
+                for j in range(len(Xs2d)-1):
+                    avg_depth = (Zs[j] + Zs[j+1]) / 2
+                    rgba = cmap_obj(norm(avg_depth))
+                    ax.plot(Xs2d[j:j+2], Ys2d[j:j+2], color=rgba,
+                            lw=linewidth*6, alpha=alpha)  # multiplying linewidth by 3 to make depth lines more visible                
+                    
+            elif colortension:    # if the mooring lines want to be plotted with colors based on node tensions
                 maxT = np.max(tensions); minT = np.min(tensions)
                 for i in range(len(Xs)-1):          # for each node in the line
                     color_ratio = ((tensions[i] + tensions[i+1])/2 - minT)/(maxT - minT)  # ratio of the node tension in relation to the max and min tension


### PR DESCRIPTION
- The user can provide a set value of maximum depth to show the most transparent part of the line. By default, this is set to the water depth. But sometimes, we might be interested in limiting the depth to the first 200m for instance or to show the depth of which it can be affected by marine growth (e.g., -170m). This is added as a variable in kwargs called max_line_depth.

Here's an example of showing lines in the first 170m of the water column:
This pull request enhances the `drawLine2d` method in `moorpy/subsystem.py` to support coloring mooring lines based on depth, in addition to the existing tension-based coloring. The update introduces a new parameter for depth-based colormapping and handles the plotting accordingly.

**Enhancements to line plotting:**

* Added a `depth_cmap_settings` parameter to the `drawLine2d` method, allowing users to specify colormap settings for coloring lines based on depth.
* Implemented logic to plot line segments with colors representing average depth between nodes when `depth_cmap_settings` is provided, using matplotlib colormaps and normalization.
* Retained and prioritized the existing tension-based colormapping as a fallback when depth-based settings are not specified.
<img width="782" height="691" alt="Screenshot 2025-10-05 at 4 52 24 PM" src="https://github.com/user-attachments/assets/63e70b01-f2ea-41ca-bdea-c877824c680d" />
